### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete URL substring sanitization

### DIFF
--- a/test/utils/remoteAssets.test.ts
+++ b/test/utils/remoteAssets.test.ts
@@ -125,7 +125,16 @@ describe("ensureLocalesAvailable", () => {
 
     const count = await ensureLocalesAvailable(dir);
     expect(count).toBe(1);
-    expect(fetchSpy.mock.calls.some((c) => String(c[0]).includes("github.com"))).toBe(true);
+    expect(
+      fetchSpy.mock.calls.some((c) => {
+        try {
+          const url = new URL(String(c[0]));
+          return url.hostname === "github.com" || url.hostname.endsWith(".github.com");
+        } catch {
+          return false;
+        }
+      })
+    ).toBe(true);
   });
 
   test("全部候选失败时返回 0，不抛异常（交由嵌入兜底）", async () => {


### PR DESCRIPTION
Potential fix for [https://github.com/Pimeng/tphira-mp/security/code-scanning/9](https://github.com/Pimeng/tphira-mp/security/code-scanning/9)

Use structured URL parsing and assert on `hostname` (or `host`) instead of substring matching the full URL string.

Best fix here (without changing functionality): in `test/utils/remoteAssets.test.ts`, replace the `.some((c) => String(c[0]).includes("github.com"))` predicate with logic that:

1. Converts the first call argument to a `URL` safely (`new URL(String(c[0]))`),
2. Compares `url.hostname` against an allow rule for GitHub host(s), e.g. exact `github.com` or subdomains via `.endsWith(".github.com")`,
3. Returns `false` if parsing fails.

This keeps the same test intent (“a GitHub fallback URL was requested”) while removing incomplete URL substring sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
